### PR TITLE
npm publishが失敗していた問題の修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,6 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,11 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-      - run: npm publish --access=public
+      - name: Run install
+        run: npm ci
+      - name: Run build
+        run: npm run build
+      - name: Run publish
+        run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,3 @@ node_modules/
 # TypeScript cache
 *.tsbuildinfo
 .npm
-
-# Artifact
-dist


### PR DESCRIPTION
## 概要

- https://github.com/hbsnow/rehype-sectionize/actions/runs/3710597047 でpublishが失敗していた問題の修正
  - `--access=public` を忘れていた
- `.npmignore` を忘れて成果物が含まれていなかった